### PR TITLE
chore: Remove Fraxtal and zkEVM

### DIFF
--- a/tasks/Fraxtal Child Chain Gauges Checkpointer/config.json
+++ b/tasks/Fraxtal Child Chain Gauges Checkpointer/config.json
@@ -2,7 +2,7 @@
   "autotaskId": "60e270d0-1515-4404-b820-1cabc995aca9",
   "actionId": "60e270d0-1515-4404-b820-1cabc995aca9",
   "name": "Fraxtal Child Chain Gauges Checkpointer",
-  "paused": false,
+  "paused": true,
   "trigger": {
     "type": "schedule",
     "cron": "*/5 * * * 4"

--- a/tasks/Mainnet Checkpoint Root Gauges/index.js
+++ b/tasks/Mainnet Checkpoint Root Gauges/index.js
@@ -55,12 +55,10 @@ exports.handler = async function (credentials, context) {
         'Polygon',
         'Base',
         'Gnosis',
-        'PolygonZkEvm',
         'Avalanche',
         'EthereumSingleRecipientGauge',
         'Arbitrum',
         'Optimism',
-        'Fraxtal',
     ]
     const store = new KeyValueStoreClient(credentials);
 


### PR DESCRIPTION
- disable Fraxtal Child chain checkpointer, archive later
- remove Fraxtal and zkevm root gauge checkpointing: there are no more active veBAL gauges present for those chains.

Note that Fraxtal chain is now in support-only mode. zkEVM will be completely shut down in a year